### PR TITLE
Update to modern runtipi configuration format

### DIFF
--- a/apps/inventree/config.json
+++ b/apps/inventree/config.json
@@ -10,7 +10,7 @@
     "utilities"
   ],
   "description": "InvenTree is an open-source inventory management system which provides intuitive parts management and stock control. Features include multi-level BOM management, stock tracking, order management, and comprehensive reporting.",
-  "tipi_version": 2,
+  "min_tipi_version": "3.0.0",
   "version": "stable",
   "source": "https://github.com/inventree/InvenTree",
   "exposable": true,

--- a/apps/inventree/docker-compose.json
+++ b/apps/inventree/docker-compose.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 2,
   "services": [
     {
       "name": "inventree-db",


### PR DESCRIPTION
- Replace tipi_version with min_tipi_version in config.json
- Add schemaVersion: 2 to docker-compose.json
- Fixes "Outdated App Configuration" warning

Modern runtipi uses min_tipi_version in config.json and schemaVersion in docker-compose.json instead of the legacy tipi_version field.