### PR TITLE
Revert to tipi_version for schema compatibility

### DIFF
--- a/apps/inventree/config.json
+++ b/apps/inventree/config.json
@@ -10,7 +10,7 @@
     "utilities"
   ],
   "description": "InvenTree is an open-source inventory management system which provides intuitive parts management and stock control. Features include multi-level BOM management, stock tracking, order management, and comprehensive reporting.",
-  "min_tipi_version": "3.0.0",
+  "tipi_version": 2,
   "version": "stable",
   "source": "https://github.com/inventree/InvenTree",
   "exposable": true,


### PR DESCRIPTION
The app store schema still requires tipi_version field. Reverted from min_tipi_version back to tipi_version: 2