### PR TITLE
Add INVENTREE_SITE_URL to worker service

### DIFF
--- a/apps/inventree/docker-compose.json
+++ b/apps/inventree/docker-compose.json
@@ -193,6 +193,10 @@
           "value": "WARNING"
         },
         {
+          "key": "INVENTREE_SITE_URL",
+          "value": "http://${APP_DOMAIN}:${APP_PORT}"
+        },
+        {
           "key": "INVENTREE_CSRF_TRUSTED_ORIGINS",
           "value": "${INVENTREE_CSRF_TRUSTED_ORIGINS}"
         }


### PR DESCRIPTION
The worker needs INVENTREE_SITE_URL to either derive CSRF_TRUSTED_ORIGINS automatically or to satisfy the configuration requirements. This fixes the 'No CSRF_TRUSTED_ORIGINS specified' error on the worker.