### PR TITLE
Fix Part-DB cache directory permissions issue

### DIFF
--- a/apps/partdb/docker-compose.json
+++ b/apps/partdb/docker-compose.json
@@ -69,10 +69,6 @@
         {
           "hostPath": "${APP_DATA_DIR}/public_media",
           "containerPath": "/var/www/html/public/media"
-        },
-        {
-          "hostPath": "${APP_DATA_DIR}/var",
-          "containerPath": "/var/www/html/var"
         }
       ],
       "internalPort": "80"


### PR DESCRIPTION
Remove /var volume mount to fix cache directory permissions error. The /var/www/html/var directory contains temporary cache and log files that don't need to be persisted. With MySQL as the database backend, this directory can be internal to the container.

This resolves the "Unable to create the cache directory" error that prevented Part-DB from starting.

Fixes: Unable to create the "cache" directory (/var/www/html/var/cache/docker)