### PR TITLE
Fix docker-compose.json environment format for schema v2

### DIFF
--- a/apps/inventree/docker-compose.json
+++ b/apps/inventree/docker-compose.json
@@ -1,31 +1,15 @@
 {
-  "schemaVersion": 2,
   "services": [
     {
       "name": "inventree-db",
       "image": "postgres:17",
-      "environment": [
-        {
-          "key": "PGDATA",
-          "value": "/var/lib/postgresql/data/pgdb"
-        },
-        {
-          "key": "POSTGRES_USER",
-          "value": "${INVENTREE_DB_USER}"
-        },
-        {
-          "key": "POSTGRES_PASSWORD",
-          "value": "${INVENTREE_DB_PASSWORD}"
-        },
-        {
-          "key": "POSTGRES_DB",
-          "value": "${INVENTREE_DB_NAME}"
-        },
-        {
-          "key": "POSTGRES_INITDB_ARGS",
-          "value": "--encoding=UTF8"
-        }
-      ],
+      "environment": {
+        "PGDATA": "/var/lib/postgresql/data/pgdb",
+        "POSTGRES_USER": "${INVENTREE_DB_USER}",
+        "POSTGRES_PASSWORD": "${INVENTREE_DB_PASSWORD}",
+        "POSTGRES_DB": "${INVENTREE_DB_NAME}",
+        "POSTGRES_INITDB_ARGS": "--encoding=UTF8"
+      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/postgresql",
@@ -44,92 +28,29 @@
       "image": "inventree/inventree:stable",
       "isMain": true,
       "dependsOn": ["inventree-db", "inventree-cache"],
-      "environment": [
-        {
-          "key": "INVENTREE_DB_ENGINE",
-          "value": "postgresql"
-        },
-        {
-          "key": "INVENTREE_DB_NAME",
-          "value": "${INVENTREE_DB_NAME}"
-        },
-        {
-          "key": "INVENTREE_DB_HOST",
-          "value": "inventree-db"
-        },
-        {
-          "key": "INVENTREE_DB_PORT",
-          "value": "5432"
-        },
-        {
-          "key": "INVENTREE_DB_USER",
-          "value": "${INVENTREE_DB_USER}"
-        },
-        {
-          "key": "INVENTREE_DB_PASSWORD",
-          "value": "${INVENTREE_DB_PASSWORD}"
-        },
-        {
-          "key": "INVENTREE_CACHE_ENABLED",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_CACHE_HOST",
-          "value": "inventree-cache"
-        },
-        {
-          "key": "INVENTREE_CACHE_PORT",
-          "value": "6379"
-        },
-        {
-          "key": "INVENTREE_PLUGINS_ENABLED",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_AUTO_UPDATE",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_LOG_LEVEL",
-          "value": "WARNING"
-        },
-        {
-          "key": "INVENTREE_ADMIN_USER",
-          "value": "${INVENTREE_ADMIN_USER}"
-        },
-        {
-          "key": "INVENTREE_ADMIN_PASSWORD",
-          "value": "${INVENTREE_ADMIN_PASSWORD}"
-        },
-        {
-          "key": "INVENTREE_ADMIN_EMAIL",
-          "value": "${INVENTREE_ADMIN_EMAIL}"
-        },
-        {
-          "key": "INVENTREE_SITE_URL",
-          "value": "http://${APP_DOMAIN}:${APP_PORT}"
-        },
-        {
-          "key": "INVENTREE_CSRF_TRUSTED_ORIGINS",
-          "value": "${INVENTREE_CSRF_TRUSTED_ORIGINS}"
-        },
-        {
-          "key": "INVENTREE_USE_X_FORWARDED_HOST",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_USE_X_FORWARDED_PORT",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_USE_X_FORWARDED_PROTO",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_GUNICORN_TIMEOUT",
-          "value": "90"
-        }
-      ],
+      "environment": {
+        "INVENTREE_DB_ENGINE": "postgresql",
+        "INVENTREE_DB_NAME": "${INVENTREE_DB_NAME}",
+        "INVENTREE_DB_HOST": "inventree-db",
+        "INVENTREE_DB_PORT": "5432",
+        "INVENTREE_DB_USER": "${INVENTREE_DB_USER}",
+        "INVENTREE_DB_PASSWORD": "${INVENTREE_DB_PASSWORD}",
+        "INVENTREE_CACHE_ENABLED": "True",
+        "INVENTREE_CACHE_HOST": "inventree-cache",
+        "INVENTREE_CACHE_PORT": "6379",
+        "INVENTREE_PLUGINS_ENABLED": "True",
+        "INVENTREE_AUTO_UPDATE": "True",
+        "INVENTREE_LOG_LEVEL": "WARNING",
+        "INVENTREE_ADMIN_USER": "${INVENTREE_ADMIN_USER}",
+        "INVENTREE_ADMIN_PASSWORD": "${INVENTREE_ADMIN_PASSWORD}",
+        "INVENTREE_ADMIN_EMAIL": "${INVENTREE_ADMIN_EMAIL}",
+        "INVENTREE_SITE_URL": "http://${APP_DOMAIN}:${APP_PORT}",
+        "INVENTREE_CSRF_TRUSTED_ORIGINS": "${INVENTREE_CSRF_TRUSTED_ORIGINS}",
+        "INVENTREE_USE_X_FORWARDED_HOST": "True",
+        "INVENTREE_USE_X_FORWARDED_PORT": "True",
+        "INVENTREE_USE_X_FORWARDED_PROTO": "True",
+        "INVENTREE_GUNICORN_TIMEOUT": "90"
+      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",
@@ -143,64 +64,22 @@
       "image": "inventree/inventree:stable",
       "command": "invoke worker",
       "dependsOn": ["inventree-server"],
-      "environment": [
-        {
-          "key": "INVENTREE_DB_ENGINE",
-          "value": "postgresql"
-        },
-        {
-          "key": "INVENTREE_DB_NAME",
-          "value": "${INVENTREE_DB_NAME}"
-        },
-        {
-          "key": "INVENTREE_DB_HOST",
-          "value": "inventree-db"
-        },
-        {
-          "key": "INVENTREE_DB_PORT",
-          "value": "5432"
-        },
-        {
-          "key": "INVENTREE_DB_USER",
-          "value": "${INVENTREE_DB_USER}"
-        },
-        {
-          "key": "INVENTREE_DB_PASSWORD",
-          "value": "${INVENTREE_DB_PASSWORD}"
-        },
-        {
-          "key": "INVENTREE_CACHE_ENABLED",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_CACHE_HOST",
-          "value": "inventree-cache"
-        },
-        {
-          "key": "INVENTREE_CACHE_PORT",
-          "value": "6379"
-        },
-        {
-          "key": "INVENTREE_PLUGINS_ENABLED",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_AUTO_UPDATE",
-          "value": "True"
-        },
-        {
-          "key": "INVENTREE_LOG_LEVEL",
-          "value": "WARNING"
-        },
-        {
-          "key": "INVENTREE_SITE_URL",
-          "value": "http://${APP_DOMAIN}:${APP_PORT}"
-        },
-        {
-          "key": "INVENTREE_CSRF_TRUSTED_ORIGINS",
-          "value": "${INVENTREE_CSRF_TRUSTED_ORIGINS}"
-        }
-      ],
+      "environment": {
+        "INVENTREE_DB_ENGINE": "postgresql",
+        "INVENTREE_DB_NAME": "${INVENTREE_DB_NAME}",
+        "INVENTREE_DB_HOST": "inventree-db",
+        "INVENTREE_DB_PORT": "5432",
+        "INVENTREE_DB_USER": "${INVENTREE_DB_USER}",
+        "INVENTREE_DB_PASSWORD": "${INVENTREE_DB_PASSWORD}",
+        "INVENTREE_CACHE_ENABLED": "True",
+        "INVENTREE_CACHE_HOST": "inventree-cache",
+        "INVENTREE_CACHE_PORT": "6379",
+        "INVENTREE_PLUGINS_ENABLED": "True",
+        "INVENTREE_AUTO_UPDATE": "True",
+        "INVENTREE_LOG_LEVEL": "WARNING",
+        "INVENTREE_SITE_URL": "http://${APP_DOMAIN}:${APP_PORT}",
+        "INVENTREE_CSRF_TRUSTED_ORIGINS": "${INVENTREE_CSRF_TRUSTED_ORIGINS}"
+      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/data",

--- a/apps/partdb/docker-compose.json
+++ b/apps/partdb/docker-compose.json
@@ -1,27 +1,14 @@
 {
-  "schemaVersion": 2,
   "services": [
     {
       "name": "partdb-db",
       "image": "mariadb:11",
-      "environment": [
-        {
-          "key": "MYSQL_DATABASE",
-          "value": "${PARTDB_DB_NAME}"
-        },
-        {
-          "key": "MYSQL_USER",
-          "value": "${PARTDB_DB_USER}"
-        },
-        {
-          "key": "MYSQL_PASSWORD",
-          "value": "${PARTDB_DB_PASSWORD}"
-        },
-        {
-          "key": "MYSQL_ROOT_PASSWORD",
-          "value": "${PARTDB_DB_PASSWORD}"
-        }
-      ],
+      "environment": {
+        "MYSQL_DATABASE": "${PARTDB_DB_NAME}",
+        "MYSQL_USER": "${PARTDB_DB_USER}",
+        "MYSQL_PASSWORD": "${PARTDB_DB_PASSWORD}",
+        "MYSQL_ROOT_PASSWORD": "${PARTDB_DB_PASSWORD}"
+      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/mysql",
@@ -35,32 +22,14 @@
       "image": "jbtronics/part-db1:latest",
       "isMain": true,
       "dependsOn": ["partdb-db"],
-      "environment": [
-        {
-          "key": "DATABASE_URL",
-          "value": "mysql://${PARTDB_DB_USER}:${PARTDB_DB_PASSWORD}@partdb-db:3306/${PARTDB_DB_NAME}"
-        },
-        {
-          "key": "APP_ENV",
-          "value": "docker"
-        },
-        {
-          "key": "DEFAULT_LANG",
-          "value": "${PARTDB_DEFAULT_LANG}"
-        },
-        {
-          "key": "DEFAULT_TIMEZONE",
-          "value": "${PARTDB_DEFAULT_TIMEZONE}"
-        },
-        {
-          "key": "BASE_CURRENCY",
-          "value": "${PARTDB_BASE_CURRENCY}"
-        },
-        {
-          "key": "TRUSTED_PROXIES",
-          "value": "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
-        }
-      ],
+      "environment": {
+        "DATABASE_URL": "mysql://${PARTDB_DB_USER}:${PARTDB_DB_PASSWORD}@partdb-db:3306/${PARTDB_DB_NAME}",
+        "APP_ENV": "docker",
+        "DEFAULT_LANG": "${PARTDB_DEFAULT_LANG}",
+        "DEFAULT_TIMEZONE": "${PARTDB_DEFAULT_TIMEZONE}",
+        "BASE_CURRENCY": "${PARTDB_BASE_CURRENCY}",
+        "TRUSTED_PROXIES": "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+      },
       "volumes": [
         {
           "hostPath": "${APP_DATA_DIR}/uploads",


### PR DESCRIPTION
Convert environment from array format to object format to match the updated @runtipi/common schema requirements.