### PR TITLE
Update Filament Profiles to current runtipi schema

### DIFF
--- a/apps/filament-profiles/config.json
+++ b/apps/filament-profiles/config.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../app-info-schema.json",
   "name": "Filament Profiles",
   "id": "filament-profiles",
   "available": true,
@@ -10,8 +11,9 @@
     "data"
   ],
   "description": "Filament Profiles is a self-hosted web application for managing 3D printer filament settings. Track optimal print configurations including temperatures, pressure advance, flow rates, and speeds for different filaments across various machines and build plates.",
-  "tipi_version": 2,
-  "version": "latest",
+  "tipi_version": 11,
+  "min_tipi_version": "4.5.0",
+  "version": "1.0.0",
   "source": "https://github.com/cori/filament-profiles",
   "exposable": true,
   "supported_architectures": [

--- a/apps/filament-profiles/docker-compose.json
+++ b/apps/filament-profiles/docker-compose.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "../dynamic-compose-schema.json",
   "services": [
     {
       "name": "filament-profiles-db",
@@ -15,7 +16,7 @@
         }
       ],
       "healthCheck": {
-        "test": "pg_isready -U ${FILAMENT_PROFILES_DB_USER} -d ${FILAMENT_PROFILES_DB_NAME}",
+        "test": "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB",
         "interval": "5s",
         "timeout": "5s",
         "retries": 5
@@ -27,6 +28,7 @@
       "image": "ghcr.io/cori/filament-profiles:main",
       "isMain": true,
       "dependsOn": ["filament-profiles-db"],
+      "command": "sh -c 'alembic upgrade head && uvicorn src.main:app --host 0.0.0.0 --port 8000'",
       "environment": {
         "DATABASE_URL": "postgresql://${FILAMENT_PROFILES_DB_USER}:${FILAMENT_PROFILES_DB_PASSWORD}@filament-profiles-db:5432/${FILAMENT_PROFILES_DB_NAME}",
         "SPOOLMAN_URL": "${SPOOLMAN_URL}",


### PR DESCRIPTION
- Update tipi_version to 11 and add min_tipi_version 4.5.0
- Add $schema references for validation
- Add command to run database migrations before starting uvicorn
- Fix healthCheck to use container environment variables
- Change version from latest to 1.0.0