### PR TITLE
Fix Filament Profiles command and healthcheck

### DIFF
--- a/apps/filament-profiles/docker-compose.json
+++ b/apps/filament-profiles/docker-compose.json
@@ -16,7 +16,7 @@
         }
       ],
       "healthCheck": {
-        "test": "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB",
+        "test": "pg_isready -U filamentprofiles",
         "interval": "5s",
         "timeout": "5s",
         "retries": 5
@@ -28,7 +28,7 @@
       "image": "ghcr.io/cori/filament-profiles:main",
       "isMain": true,
       "dependsOn": ["filament-profiles-db"],
-      "command": "sh -c 'alembic upgrade head && uvicorn src.main:app --host 0.0.0.0 --port 8000'",
+      "command": "sh -c 'alembic upgrade head && uvicorn filamentprofiles.main:app --host 0.0.0.0 --port 8000'",
       "environment": {
         "DATABASE_URL": "postgresql://${FILAMENT_PROFILES_DB_USER}:${FILAMENT_PROFILES_DB_PASSWORD}@filament-profiles-db:5432/${FILAMENT_PROFILES_DB_NAME}",
         "SPOOLMAN_URL": "${SPOOLMAN_URL}",


### PR DESCRIPTION
- Fix uvicorn module path: filamentprofiles.main:app (not src.main:app)
- Simplify healthcheck to match upstream: pg_isready -U filamentprofiles