### PR TITLE
Fix Blinko postgres data directory permissions issue

### DIFF
--- a/apps/blinko/docker-compose.json
+++ b/apps/blinko/docker-compose.json
@@ -8,6 +8,7 @@
         { "key": "POSTGRES_DB", "value": "blinko" },
         { "key": "POSTGRES_USER", "value": "postgres" },
         { "key": "POSTGRES_PASSWORD", "value": "${BLINKO_DB_PASSWORD}" },
+        { "key": "PGDATA", "value": "/var/lib/postgresql/data/pgdata" },
         { "key": "TZ", "value": "${TZ}" }
       ],
       "volumes": [


### PR DESCRIPTION
Set PGDATA to a subdirectory (/var/lib/postgresql/data/pgdata) so Postgres can manage its own directory permissions inside the mounted volume, avoiding the "invalid permissions" error on init.

https://claude.ai/code/session_019m3GBzRb79w8NVTVWesEVA