### PR TITLE
chore: bump fpv-inventory to sha-88eef08 (tipi_version 5)

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -7,15 +7,15 @@
   "port": 8385,
   "categories": ["utilities", "data"],
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "min_tipi_version": "4.5.0",
-  "version": "sha-0a57147",
+  "version": "sha-88eef08",
   "source": "https://github.com/cori/fpv-inventory",
   "website": "https://github.com/cori/fpv-inventory",
   "exposable": true,
   "supported_architectures": ["arm64", "amd64"],
   "created_at": 1740700800000,
-  "updated_at": 1773187200000,
+  "updated_at": 1773705600000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/cori/fpv-inventory:sha-0a57147",
+      "image": "ghcr.io/cori/fpv-inventory:sha-88eef08",
       "isMain": true,
       "environment": [
         { "key": "DB_PATH", "value": "/data/fpv-inventory.db" },


### PR DESCRIPTION
## Summary
- Updates `fpv-inventory` image tag from `sha-0a57147` → `sha-88eef08`
- Bumps `tipi_version` 4 → 5
- Updates `updated_at` timestamp to 2026-03-17

This picks up the three improvements landed in cori/fpv-inventory#27:
- **#12** — Part detail page shows parent assembly name with a link
- **#11** — New `/parts/new` full-details add form (name, type, status, qty, notes, specs); quick-add links to it
- **#9** — `specs` field for pasting raw product spec blocks, kept separate from personal notes

## Test plan
- [x] `bun test` — 48 tests pass