### PR TITLE
Configure hermes-webui to connect to existing Hermes gateway

### DIFF
--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -11,7 +11,7 @@
     "utilities"
   ],
   "description": "Hermes WebUI is a lightweight, dark-themed web interface for Hermes Agent. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
-  "tipi_version": 1,
+  "tipi_version": 2,
   "version": "0.51.345",
   "source": "https://github.com/nesquena/hermes-webui",
   "website": "https://github.com/nesquena/hermes-webui",
@@ -24,6 +24,14 @@
   "updated_at": 1780963200000,
   "dynamic_config": true,
   "form_fields": [
+    {
+      "type": "text",
+      "label": "Gateway URL",
+      "hint": "URL of your existing Hermes Agent gateway (e.g. http://192.168.1.10:8642)",
+      "required": true,
+      "env_variable": "HERMES_WEBUI_GATEWAY_BASE_URL",
+      "default": ""
+    },
     {
       "type": "password",
       "label": "Password",

--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -10,7 +10,7 @@
     "ai",
     "utilities"
   ],
-  "description": "Hermes WebUI is a lightweight, dark-themed web interface for Hermes Agent. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
+  "description": "Hermes WebUI is a lightweight, dark-themed web interface that connects to your existing Hermes Agent gateway, sharing sessions and history with the CLI and other interfaces. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
   "tipi_version": 2,
   "version": "0.51.345",
   "source": "https://github.com/nesquena/hermes-webui",
@@ -21,7 +21,7 @@
     "amd64"
   ],
   "created_at": 1780963200000,
-  "updated_at": 1780963200000,
+  "updated_at": 1781049600000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/hermes-webui/docker-compose.json
+++ b/apps/hermes-webui/docker-compose.json
@@ -10,6 +10,8 @@
         { "key": "HERMES_WEBUI_HOST", "value": "0.0.0.0" },
         { "key": "HERMES_WEBUI_PORT", "value": "8787" },
         { "key": "HERMES_WEBUI_STATE_DIR", "value": "/data" },
+        { "key": "HERMES_WEBUI_CHAT_BACKEND", "value": "gateway" },
+        { "key": "HERMES_WEBUI_GATEWAY_BASE_URL", "value": "${HERMES_WEBUI_GATEWAY_BASE_URL}" },
         { "key": "HERMES_WEBUI_PASSWORD", "value": "${HERMES_WEBUI_PASSWORD}" },
         { "key": "HERMES_WEBUI_DEFAULT_MODEL", "value": "${HERMES_WEBUI_DEFAULT_MODEL}" }
       ],

--- a/apps/hermes-webui/metadata/description.md
+++ b/apps/hermes-webui/metadata/description.md
@@ -1,18 +1,19 @@
 # Hermes WebUI
 
-A lightweight browser interface for [Hermes Agent](https://github.com/nesquena/hermes), providing a three-panel layout with session management, chat, and workspace file browsing.
+A lightweight browser interface for [Hermes Agent](https://github.com/nesquena/hermes), providing a three-panel layout with session management, chat, and workspace file browsing. Connects to your existing Hermes Agent gateway so sessions and history are shared with the CLI and other interfaces.
 
 ## Features
 
 - Dark-themed web UI with near-complete CLI parity
 - Session management and workspace file browser
+- Shares sessions/history with your existing Hermes Agent instance
 - Compatible with **Hermes Agent Mobile** (iOS app) — set a password to enable
-- Supports a default model override per deployment
 
 ## Configuration
 
 | Field | Description |
 |---|---|
+| **Gateway URL** | URL of your already-running Hermes Agent gateway (e.g. `http://192.168.1.10:8642`). Required. |
 | **Password** | Protects the UI with HTTP authentication. Required when connecting from Hermes Agent Mobile. |
 | **Default Model** | Override the agent's default model (e.g. `claude-sonnet-4-6`). Leave blank to use the agent's own default. |
 
@@ -23,5 +24,5 @@ A lightweight browser interface for [Hermes Agent](https://github.com/nesquena/h
 
 ## Notes
 
-- State and sessions are persisted to the app data directory.
-- If you are running Hermes Agent separately, ensure both containers can reach each other on your network.
+- Your Hermes Agent gateway must be network-reachable from this container (Tailscale, LAN, or Docker network).
+- WebUI state (UI preferences, etc.) is persisted to the app data directory; session history lives in the gateway.


### PR DESCRIPTION
## Summary

- Adds `HERMES_WEBUI_GATEWAY_BASE_URL` as a required form field — the URL of the user's already-running Hermes Agent gateway
- Hardcodes `HERMES_WEBUI_CHAT_BACKEND=gateway` so the UI shares sessions/history with the existing agent rather than spinning up an isolated in-process agent
- Updates description.md to reflect gateway-connected setup

## Why

The default single-container mode runs an embedded in-process agent, completely isolated from any existing Hermes Agent instance. This change makes the WebUI act as a second frontend to the existing gateway instead.

## Test plan

- [ ] `bun test` passes (54 tests, verified locally)
- [ ] Install via Runtipi, set Gateway URL to existing Hermes gateway, confirm sessions are shared

https://claude.ai/code/session_01Xwf5nZf6d1npMerNteodq2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xwf5nZf6d1npMerNteodq2)_