### PR TITLE
Skip first-run onboarding wizard in gateway mode

### DIFF
--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -11,7 +11,7 @@
     "utilities"
   ],
   "description": "Hermes WebUI is a lightweight, dark-themed web interface that connects to your existing Hermes Agent gateway, sharing sessions and history with the CLI and other interfaces. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
-  "tipi_version": 2,
+  "tipi_version": 3,
   "version": "0.51.345",
   "source": "https://github.com/nesquena/hermes-webui",
   "website": "https://github.com/nesquena/hermes-webui",
@@ -21,7 +21,7 @@
     "amd64"
   ],
   "created_at": 1780963200000,
-  "updated_at": 1781049600000,
+  "updated_at": 1781136000000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/hermes-webui/docker-compose.json
+++ b/apps/hermes-webui/docker-compose.json
@@ -11,6 +11,7 @@
         { "key": "HERMES_WEBUI_PORT", "value": "8787" },
         { "key": "HERMES_WEBUI_STATE_DIR", "value": "/data" },
         { "key": "HERMES_WEBUI_CHAT_BACKEND", "value": "gateway" },
+        { "key": "HERMES_WEBUI_SKIP_ONBOARDING", "value": "1" },
         { "key": "HERMES_WEBUI_GATEWAY_BASE_URL", "value": "${HERMES_WEBUI_GATEWAY_BASE_URL}" },
         { "key": "HERMES_WEBUI_PASSWORD", "value": "${HERMES_WEBUI_PASSWORD}" },
         { "key": "HERMES_WEBUI_DEFAULT_MODEL", "value": "${HERMES_WEBUI_DEFAULT_MODEL}" }


### PR DESCRIPTION
## Summary

- Sets `HERMES_WEBUI_SKIP_ONBOARDING=1` in the container environment
- When connecting to an existing Hermes gateway the provider/API config already lives on the gateway — the first-run wizard is redundant and confusing

## Why

On fresh install the WebUI presents a wizard to configure a local gateway and upstream provider. Since this app definition always runs in gateway mode (`HERMES_WEBUI_CHAT_BACKEND=gateway`) against a user-supplied `HERMES_WEBUI_GATEWAY_BASE_URL`, the wizard should never appear.

## Test plan

- [ ] `bun test` passes (54 tests, verified locally)
- [ ] Fresh install no longer shows the onboarding wizard on first login

https://claude.ai/code/session_01Xwf5nZf6d1npMerNteodq2

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xwf5nZf6d1npMerNteodq2)_