### PR TITLE
Expose HERMES_WEBUI_GATEWAY_API_KEY as a form field

### DIFF
--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -11,7 +11,7 @@
     "utilities"
   ],
   "description": "Hermes WebUI is a lightweight, dark-themed web interface that connects to your existing Hermes Agent gateway, sharing sessions and history with the CLI and other interfaces. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
-  "tipi_version": 3,
+  "tipi_version": 4,
   "version": "0.51.345",
   "source": "https://github.com/nesquena/hermes-webui",
   "website": "https://github.com/nesquena/hermes-webui",
@@ -21,21 +21,29 @@
     "amd64"
   ],
   "created_at": 1780963200000,
-  "updated_at": 1781136000000,
+  "updated_at": 1781308800000,
   "dynamic_config": true,
   "form_fields": [
     {
       "type": "text",
       "label": "Gateway URL",
-      "hint": "URL of your existing Hermes Agent gateway (e.g. http://192.168.1.10:8642)",
+      "hint": "URL of your existing Hermes Agent gateway (e.g. http://192.168.1.10:8642). Use the gateway port (default 8642), not the dashboard port (9119).",
       "required": true,
       "env_variable": "HERMES_WEBUI_GATEWAY_BASE_URL",
       "default": ""
     },
     {
       "type": "password",
-      "label": "Password",
-      "hint": "Password for web UI access. Required when using Hermes Agent Mobile (iOS app).",
+      "label": "Gateway API Key",
+      "hint": "Bearer token matching the gateway's API_SERVER_KEY (from ~/.hermes/.env on the gateway host). Required if the gateway has API_SERVER_KEY set.",
+      "required": false,
+      "env_variable": "HERMES_WEBUI_GATEWAY_API_KEY",
+      "default": ""
+    },
+    {
+      "type": "password",
+      "label": "WebUI Password",
+      "hint": "Password to log in to this web UI (separate from the gateway key). Required when using Hermes Agent Mobile (iOS app).",
       "required": false,
       "env_variable": "HERMES_WEBUI_PASSWORD",
       "default": ""

--- a/apps/hermes-webui/docker-compose.json
+++ b/apps/hermes-webui/docker-compose.json
@@ -13,6 +13,7 @@
         { "key": "HERMES_WEBUI_CHAT_BACKEND", "value": "gateway" },
         { "key": "HERMES_WEBUI_SKIP_ONBOARDING", "value": "1" },
         { "key": "HERMES_WEBUI_GATEWAY_BASE_URL", "value": "${HERMES_WEBUI_GATEWAY_BASE_URL}" },
+        { "key": "HERMES_WEBUI_GATEWAY_API_KEY", "value": "${HERMES_WEBUI_GATEWAY_API_KEY}" },
         { "key": "HERMES_WEBUI_PASSWORD", "value": "${HERMES_WEBUI_PASSWORD}" },
         { "key": "HERMES_WEBUI_DEFAULT_MODEL", "value": "${HERMES_WEBUI_DEFAULT_MODEL}" }
       ],

--- a/apps/hermes-webui/metadata/description.md
+++ b/apps/hermes-webui/metadata/description.md
@@ -13,8 +13,9 @@ A lightweight browser interface for [Hermes Agent](https://github.com/nesquena/h
 
 | Field | Description |
 |---|---|
-| **Gateway URL** | URL of your already-running Hermes Agent gateway (e.g. `http://192.168.1.10:8642`). Required. |
-| **Password** | Protects the UI with HTTP authentication. Required when connecting from Hermes Agent Mobile. |
+| **Gateway URL** | URL of your already-running Hermes Agent gateway (e.g. `http://192.168.1.10:8642`). Use the **gateway** port (default `8642`), not the **dashboard** port (`9119`). Required. |
+| **Gateway API Key** | Bearer token that matches the gateway's `API_SERVER_KEY` (typically set in `~/.hermes/.env` on the gateway host). Required if the gateway enforces auth — without it, sessions and model lists silently come back empty and chat messages fail. |
+| **WebUI Password** | Protects this UI with HTTP authentication (separate from the gateway key). Required when connecting from Hermes Agent Mobile. |
 | **Default Model** | Override the agent's default model (e.g. `claude-sonnet-4-6`). Leave blank to use the agent's own default. |
 
 ## Usage with Hermes Agent Mobile (iOS)


### PR DESCRIPTION
The WebUI talks to the Hermes gateway's OpenAI-compatible API server, which enforces bearer-token auth via API_SERVER_KEY. Without a matching HERMES_WEBUI_GATEWAY_API_KEY, the unauthenticated /health probe still passes (so the agent looks alive in /api/health/agent) but session listings, model catalogs, skills, and MCPs come back empty and chats fail to send — the WebUI looks half-broken in a way that's hard to attribute to auth.

Surface the key as a password field in Runtipi config, plumb it through docker-compose.json, and document the gateway-vs-dashboard port distinction (8642 vs 9119) in description.md and the Gateway URL hint, since that was a separate source of confusion.