### PR TITLE
Bind-mount host ~/.hermes into hermes-webui container

### DIFF
--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -11,7 +11,7 @@
     "utilities"
   ],
   "description": "Hermes WebUI is a lightweight, dark-themed web interface that connects to your existing Hermes Agent gateway, sharing sessions and history with the CLI and other interfaces. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
-  "tipi_version": 4,
+  "tipi_version": 5,
   "version": "0.51.345",
   "source": "https://github.com/nesquena/hermes-webui",
   "website": "https://github.com/nesquena/hermes-webui",
@@ -21,9 +21,17 @@
     "amd64"
   ],
   "created_at": 1780963200000,
-  "updated_at": 1781308800000,
+  "updated_at": 1781356000000,
   "dynamic_config": true,
   "form_fields": [
+    {
+      "type": "text",
+      "label": "Hermes Home Host Path",
+      "hint": "Absolute path to your Hermes home directory on this host (e.g. /home/youruser/.hermes). Bind-mounted into the container so the WebUI can import the hermes-agent source it finds at <path>/hermes-agent. Without this, skills, MCPs, crons, and kanban return errors in the UI.",
+      "required": true,
+      "env_variable": "HERMES_HOME_HOST_PATH",
+      "default": ""
+    },
     {
       "type": "text",
       "label": "Gateway URL",

--- a/apps/hermes-webui/docker-compose.json
+++ b/apps/hermes-webui/docker-compose.json
@@ -18,7 +18,8 @@
         { "key": "HERMES_WEBUI_DEFAULT_MODEL", "value": "${HERMES_WEBUI_DEFAULT_MODEL}" }
       ],
       "volumes": [
-        { "hostPath": "${APP_DATA_DIR}/data", "containerPath": "/data" }
+        { "hostPath": "${APP_DATA_DIR}/data", "containerPath": "/data" },
+        { "hostPath": "${HERMES_HOME_HOST_PATH}", "containerPath": "/home/hermeswebui/.hermes" }
       ]
     }
   ]

--- a/apps/hermes-webui/metadata/description.md
+++ b/apps/hermes-webui/metadata/description.md
@@ -13,10 +13,17 @@ A lightweight browser interface for [Hermes Agent](https://github.com/nesquena/h
 
 | Field | Description |
 |---|---|
+| **Hermes Home Host Path** | Absolute path to your Hermes home directory on the Runtipi host (e.g. `/home/youruser/.hermes`). The WebUI image is a thin shell that imports the `hermes-agent` Python package in-process; the directory you point at must contain a `hermes-agent/` subdirectory with the agent source. Required. |
 | **Gateway URL** | URL of your already-running Hermes Agent gateway (e.g. `http://192.168.1.10:8642`). Use the **gateway** port (default `8642`), not the **dashboard** port (`9119`). Required. |
 | **Gateway API Key** | Bearer token that matches the gateway's `API_SERVER_KEY` (typically set in `~/.hermes/.env` on the gateway host). Required if the gateway enforces auth — without it, sessions and model lists silently come back empty and chat messages fail. |
 | **WebUI Password** | Protects this UI with HTTP authentication (separate from the gateway key). Required when connecting from Hermes Agent Mobile. |
 | **Default Model** | Override the agent's default model (e.g. `claude-sonnet-4-6`). Leave blank to use the agent's own default. |
+
+### Why the Hermes Home mount is required
+
+Chat messages route over HTTP to the configured gateway, but WebUI sidebars (skills, MCP servers, crons, kanban, plugin visibility) are implemented by importing the `hermes-agent` Python package directly. The published Docker image does not include that package; it expects to find it on a bind-mounted volume at `/home/hermeswebui/.hermes/hermes-agent`. Bind-mounting your existing `~/.hermes` from the host satisfies that requirement and also shares sessions, credentials, and MCP config with your native agent install.
+
+Permissions: the directory must be readable by the UID that owns it on the host. The container auto-detects UID/GID from the mounted directory at startup.
 
 ## Usage with Hermes Agent Mobile (iOS)
 


### PR DESCRIPTION
The WebUI image is a thin Python server that imports the hermes-agent package in-process to serve /api/skills, /api/crons, /api/mcp/*, kanban, and plugin visibility. Without the agent source on disk those endpoints return 500 ModuleNotFoundError ('agent', 'cron', 'hermes_cli', 'tools').

Only chat completions and session data route through the gateway over HTTP; everything else is read locally. Upstream's docker-compose.yml mounts host ~/.hermes at /home/hermeswebui/.hermes for exactly this reason — the WebUI's startup script finds <home>/hermes-agent and pip-installs it into the container's venv.

Adds a required Hermes Home Host Path form field, bind-mounts it, documents the why in description.md, bumps tipi_version 4 → 5.