### PR TITLE
Add Copilot review + auto-merge workflow

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -43,7 +43,7 @@ jobs:
                 }
               }
             ' \
-            --jq '[.data.repository.suggestedActors.nodes[] | select(.login == "Copilot" or .login == "copilot-pull-request-reviewer") | .id] | first // ""')
+            --jq '[.data.repository.suggestedActors.nodes[] | select(.login == "Copilot" or .login == "Copilot[bot]" or .login == "copilot-pull-request-reviewer" or .login == "copilot-pull-request-reviewer[bot]") | .id] | first // ""')
 
           if [ -z "$copilot_id" ]; then
             echo "::warning::Copilot reviewer not available on this repo. Enable Copilot code review in repo settings."

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,102 @@
+name: Copilot review and auto-merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  request-copilot-review:
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Request Copilot review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          NAME: ${{ github.event.repository.name }}
+          PR_NODE_ID: ${{ github.event.pull_request.node_id }}
+        run: |
+          # Copilot can't be requested via the REST `requested_reviewers`
+          # endpoint (it rejects non-collaborators). Use the GraphQL
+          # `suggestedActors` lookup to find Copilot's bot id, then call
+          # `requestReviews`. This mirrors GitHub's official MCP behavior.
+          copilot_id=$(gh api graphql \
+            -F owner="$OWNER" \
+            -F name="$NAME" \
+            -f query='
+              query($owner: String!, $name: String!) {
+                repository(owner: $owner, name: $name) {
+                  suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 100) {
+                    nodes {
+                      login
+                      ... on Bot { id }
+                      ... on User { id }
+                    }
+                  }
+                }
+              }
+            ' \
+            --jq '[.data.repository.suggestedActors.nodes[] | select(.login == "Copilot" or .login == "copilot-pull-request-reviewer") | .id] | first // ""')
+
+          if [ -z "$copilot_id" ]; then
+            echo "::warning::Copilot reviewer not available on this repo. Enable Copilot code review in repo settings."
+            exit 0
+          fi
+
+          gh api graphql \
+            -F pullRequestId="$PR_NODE_ID" \
+            -F userId="$copilot_id" \
+            -f query='
+              mutation($pullRequestId: ID!, $userId: ID!) {
+                requestReviews(input: {pullRequestId: $pullRequestId, userIds: [$userId]}) {
+                  pullRequest { id }
+                }
+              }
+            '
+
+  auto-merge-on-clean-copilot-review:
+    if: >-
+      github.event_name == 'pull_request_review' &&
+      github.event.review.user.login == 'copilot-pull-request-reviewer[bot]' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Decide whether Copilot requested any changes
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          REVIEW_ID: ${{ github.event.review.id }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+        run: |
+          if [ "$REVIEW_STATE" = "changes_requested" ]; then
+            echo "Copilot requested changes; skipping auto-merge."
+            echo "merge=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          inline_count=$(gh api "repos/$REPO/pulls/$PR/reviews/$REVIEW_ID/comments" --jq 'length')
+          if [ "$inline_count" -gt 0 ]; then
+            echo "Copilot left $inline_count inline comment(s); skipping auto-merge."
+            echo "merge=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Copilot review is clean; enabling auto-merge."
+            echo "merge=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Enable auto-merge
+        if: steps.check.outputs.merge == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: gh pr merge "$PR" --repo "$REPO" --squash --auto


### PR DESCRIPTION
## Summary
- Fans in the Copilot review + auto-merge workflow from `claude-code-base` (branch `claude/great-clarke-fpor65`) so it can be exercised here, where PR traffic is heavier.
- On `pull_request` (opened / ready_for_review), looks up Copilot's bot id via GraphQL `suggestedActors` and requests a review.
- On `pull_request_review` from `copilot-pull-request-reviewer[bot]`, enables squash auto-merge if the review is clean (no `changes_requested`, no inline comments).
- Workflow-level perms are read-only; each job opts into the writes it needs.

## Test plan
- [ ] Confirm Copilot code review is enabled in repo settings.
- [ ] Watch this PR's Actions run — `request-copilot-review` should succeed and a Copilot review should be requested.
- [ ] If Copilot returns a clean review, verify `auto-merge-on-clean-copilot-review` enables squash auto-merge.
- [ ] Open a follow-up PR with a deliberate nit to confirm auto-merge is correctly skipped when Copilot leaves inline comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)