### PR TITLE
hermes-webui: bump to 0.52.0

### DIFF
--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -12,7 +12,7 @@
   ],
   "description": "Hermes WebUI is a lightweight, dark-themed web interface that connects to your existing Hermes Agent gateway, sharing sessions and history with the CLI and other interfaces. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
   "tipi_version": 5,
-  "version": "0.51.345",
+  "version": "0.52.0",
   "source": "https://github.com/nesquena/hermes-webui",
   "website": "https://github.com/nesquena/hermes-webui",
   "exposable": true,
@@ -21,7 +21,7 @@
     "amd64"
   ],
   "created_at": 1780963200000,
-  "updated_at": 1781356000000,
+  "updated_at": 1783697796646,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/hermes-webui/docker-compose.json
+++ b/apps/hermes-webui/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "hermes-webui",
-      "image": "ghcr.io/nesquena/hermes-webui:0.51.345",
+      "image": "ghcr.io/nesquena/hermes-webui:0.52.0",
       "isMain": true,
       "internalPort": "8787",
       "environment": [


### PR DESCRIPTION
Bump hermes-webui Docker image from 0.51.345 to 0.52.0 (latest release).

Changes:
- `config.json`: version 0.51.345 → 0.52.0, tipi_version 4 → 5, updated_at refreshed
- `docker-compose.json`: image tag 0.51.345 → 0.52.0

Tests: 54/54 pass (`bun test`)