### PR TITLE
app: update hermes-webui to v0.52.106 (cori/hermes-webui fork)

### DIFF
--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -11,17 +11,17 @@
     "utilities"
   ],
   "description": "Hermes WebUI is a lightweight, dark-themed web interface that connects to your existing Hermes Agent gateway, sharing sessions and history with the CLI and other interfaces. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
-  "tipi_version": 5,
-  "version": "0.52.0",
-  "source": "https://github.com/nesquena/hermes-webui",
-  "website": "https://github.com/nesquena/hermes-webui",
+  "tipi_version": 6,
+  "version": "0.52.106",
+  "source": "https://github.com/cori/hermes-webui",
+  "website": "https://github.com/cori/hermes-webui",
   "exposable": true,
   "supported_architectures": [
     "arm64",
     "amd64"
   ],
   "created_at": 1780963200000,
-  "updated_at": 1783697796646,
+  "updated_at": 1786463511241,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/hermes-webui/docker-compose.json
+++ b/apps/hermes-webui/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "hermes-webui",
-      "image": "ghcr.io/nesquena/hermes-webui:0.52.0",
+      "image": "ghcr.io/cori/hermes-webui:0.52.106",
       "isMain": true,
       "internalPort": "8787",
       "environment": [


### PR DESCRIPTION
Updates the hermes-webui app from upstream v0.52.0 to v0.52.106 using the cori/hermes-webui fork.

Changes:
- Image: ghcr.io/cori/hermes-webui:0.52.106 (was ghcr.io/nesquena/hermes-webui:0.52.0)
- tipi_version: 6 (was 5)
- version: 0.52.106 (was 0.52.0)
- source/website: https://github.com/cori/hermes-webui
- updated_at: updated to current timestamp

The hermes-webui release workflow now pushes Docker images to both ghcr.io/nesquena/hermes-webui and ghcr.io/cori/hermes-webui, so the image will be available at the fork registry.

All validation tests pass.