### PR TITLE
app: update hermes-webui to 032c3472 (auto)

### DIFF
--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -11,8 +11,8 @@
     "utilities"
   ],
   "description": "Hermes WebUI is a lightweight, dark-themed web interface that connects to your existing Hermes Agent gateway, sharing sessions and history with the CLI and other interfaces. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
-  "tipi_version": 6,
-  "version": "0.52.106",
+  "tipi_version": 7,
+  "version": "032c3472",
   "source": "https://github.com/cori/hermes-webui",
   "website": "https://github.com/cori/hermes-webui",
   "exposable": true,
@@ -21,7 +21,7 @@
     "amd64"
   ],
   "created_at": 1780963200000,
-  "updated_at": 1786463511241,
+  "updated_at": 1786503819000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/hermes-webui/docker-compose.json
+++ b/apps/hermes-webui/docker-compose.json
@@ -3,23 +3,56 @@
   "services": [
     {
       "name": "hermes-webui",
-      "image": "ghcr.io/cori/hermes-webui:0.52.106",
+      "image": "ghcr.io/cori/hermes-webui:032c3472",
       "isMain": true,
       "internalPort": "8787",
       "environment": [
-        { "key": "HERMES_WEBUI_HOST", "value": "0.0.0.0" },
-        { "key": "HERMES_WEBUI_PORT", "value": "8787" },
-        { "key": "HERMES_WEBUI_STATE_DIR", "value": "/data" },
-        { "key": "HERMES_WEBUI_CHAT_BACKEND", "value": "gateway" },
-        { "key": "HERMES_WEBUI_SKIP_ONBOARDING", "value": "1" },
-        { "key": "HERMES_WEBUI_GATEWAY_BASE_URL", "value": "${HERMES_WEBUI_GATEWAY_BASE_URL}" },
-        { "key": "HERMES_WEBUI_GATEWAY_API_KEY", "value": "${HERMES_WEBUI_GATEWAY_API_KEY}" },
-        { "key": "HERMES_WEBUI_PASSWORD", "value": "${HERMES_WEBUI_PASSWORD}" },
-        { "key": "HERMES_WEBUI_DEFAULT_MODEL", "value": "${HERMES_WEBUI_DEFAULT_MODEL}" }
+        {
+          "key": "HERMES_WEBUI_HOST",
+          "value": "0.0.0.0"
+        },
+        {
+          "key": "HERMES_WEBUI_PORT",
+          "value": "8787"
+        },
+        {
+          "key": "HERMES_WEBUI_STATE_DIR",
+          "value": "/data"
+        },
+        {
+          "key": "HERMES_WEBUI_CHAT_BACKEND",
+          "value": "gateway"
+        },
+        {
+          "key": "HERMES_WEBUI_SKIP_ONBOARDING",
+          "value": "1"
+        },
+        {
+          "key": "HERMES_WEBUI_GATEWAY_BASE_URL",
+          "value": "${HERMES_WEBUI_GATEWAY_BASE_URL}"
+        },
+        {
+          "key": "HERMES_WEBUI_GATEWAY_API_KEY",
+          "value": "${HERMES_WEBUI_GATEWAY_API_KEY}"
+        },
+        {
+          "key": "HERMES_WEBUI_PASSWORD",
+          "value": "${HERMES_WEBUI_PASSWORD}"
+        },
+        {
+          "key": "HERMES_WEBUI_DEFAULT_MODEL",
+          "value": "${HERMES_WEBUI_DEFAULT_MODEL}"
+        }
       ],
       "volumes": [
-        { "hostPath": "${APP_DATA_DIR}/data", "containerPath": "/data" },
-        { "hostPath": "${HERMES_HOME_HOST_PATH}", "containerPath": "/home/hermeswebui/.hermes" }
+        {
+          "hostPath": "${APP_DATA_DIR}/data",
+          "containerPath": "/data"
+        },
+        {
+          "hostPath": "${HERMES_HOME_HOST_PATH}",
+          "containerPath": "/home/hermeswebui/.hermes"
+        }
       ]
     }
   ]


### PR DESCRIPTION
Automated update from hermes-webui push to master.

  - Version: 032c3472
  - tipi_version: 7
  - Image: ghcr.io/cori/hermes-webui:032c3472

  All validation tests pass.