### PR TITLE
app: update hermes-webui to 8d74166 (auto)

### DIFF
--- a/apps/hermes-webui/config.json
+++ b/apps/hermes-webui/config.json
@@ -11,8 +11,8 @@
     "utilities"
   ],
   "description": "Hermes WebUI is a lightweight, dark-themed web interface that connects to your existing Hermes Agent gateway, sharing sessions and history with the CLI and other interfaces. It provides near-complete parity with the CLI experience via a three-panel layout with session management, chat, and workspace file browsing. Use it in any browser, or pair it with the Hermes Agent Mobile iOS app by setting a password.",
-  "tipi_version": 7,
-  "version": "eea9e94",
+  "tipi_version": 8,
+  "version": "8d74166",
   "source": "https://github.com/cori/hermes-webui",
   "website": "https://github.com/cori/hermes-webui",
   "exposable": true,
@@ -21,7 +21,7 @@
     "amd64"
   ],
   "created_at": 1780963200000,
-  "updated_at": 1786506436000,
+  "updated_at": 1786555789000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/hermes-webui/docker-compose.json
+++ b/apps/hermes-webui/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "hermes-webui",
-      "image": "ghcr.io/cori/hermes-webui:sha-eea9e94",
+      "image": "ghcr.io/cori/hermes-webui:sha-8d74166",
       "isMain": true,
       "internalPort": "8787",
       "environment": [


### PR DESCRIPTION
Automated update from hermes-webui push to master.

  - Version: 8d74166
  - tipi_version: 8
  - Image: ghcr.io/cori/hermes-webui:sha-8d74166

  All validation tests pass.