### PR TITLE
app: update fpv-inventory to sha-fd80e37 (auto)

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -10,9 +10,9 @@
     "data"
   ],
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
-  "tipi_version": 14,
+  "tipi_version": 15,
   "min_tipi_version": "4.5.0",
-  "version": "sha-a8a11ad",
+  "version": "sha-fd80e37",
   "source": "https://github.com/cori/fpv-inventory",
   "website": "https://github.com/cori/fpv-inventory",
   "exposable": true,

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/cori/fpv-inventory:sha-a8a11ad",
+      "image": "ghcr.io/fpvibe/fpv-inventory:sha-fd80e37",
       "isMain": true,
       "environment": [
         { "key": "DB_PATH", "value": "/data/fpv-inventory.db" },


### PR DESCRIPTION
Automated update from fpv-inventory push to main.

- Version: sha-fd80e37
- tipi_version: 15
- Image: ghcr.io/fpvibe/fpv-inventory:sha-fd80e37

All validation tests pass.