### PR TITLE
fix: update fpv-inventory to ghcr.io/fpvibe after repo transfer

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -10,18 +10,18 @@
     "data"
   ],
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
-  "tipi_version": 14,
+  "tipi_version": 15,
   "min_tipi_version": "4.5.0",
-  "version": "sha-a8a11ad",
-  "source": "https://github.com/cori/fpv-inventory",
-  "website": "https://github.com/cori/fpv-inventory",
+  "version": "sha-fd80e37",
+  "source": "https://github.com/FPVibe/fpv-inventory",
+  "website": "https://github.com/FPVibe/fpv-inventory",
   "exposable": true,
   "supported_architectures": [
     "arm64",
     "amd64"
   ],
   "created_at": 1740700800000,
-  "updated_at": 1773705600000,
+  "updated_at": 1786595610000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/cori/fpv-inventory:sha-a8a11ad",
+      "image": "ghcr.io/fpvibe/fpv-inventory:sha-fd80e37",
       "isMain": true,
       "environment": [
         { "key": "DB_PATH", "value": "/data/fpv-inventory.db" },


### PR DESCRIPTION
The repo moved from cori/fpv-inventory to FPVibe/fpv-inventory. Images now live at ghcr.io/fpvibe/fpv-inventory.

- Image: `ghcr.io/cori/fpv-inventory:sha-a8a11ad` → `ghcr.io/fpvibe/fpv-inventory:sha-fd80e37`
- Source/website: `github.com/cori` → `github.com/FPVibe`
- tipi_version: 14 → 15

Resolves the "manifest unknown" error when Runtipi tries to pull the image.