### PR TITLE
fix: use public ghcr.io/cori package until fpvibe visibility is fixed

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -12,7 +12,7 @@
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
   "tipi_version": 15,
   "min_tipi_version": "4.5.0",
-  "version": "sha-fd80e37",
+  "version": "sha-876d6d3",
   "source": "https://github.com/FPVibe/fpv-inventory",
   "website": "https://github.com/FPVibe/fpv-inventory",
   "exposable": true,

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/fpvibe/fpv-inventory:sha-fd80e37",
+      "image": "ghcr.io/cori/fpv-inventory:sha-876d6d3",
       "isMain": true,
       "environment": [
         { "key": "DB_PATH", "value": "/data/fpv-inventory.db" },


### PR DESCRIPTION
The ghcr.io/fpvibe/fpv-inventory package is private (requires authentication), so Runtipi cannot pull it. This reverts the image tag back to the public ghcr.io/cori/fpv-inventory package while keeping the source/website URLs updated to FPVibe.

Once the fpvibe package visibility is changed to public, we can switch back.