### PR TITLE
fix: switch fpv-inventory to ghcr.io/fpvibe now that package is public

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -12,7 +12,7 @@
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
   "tipi_version": 15,
   "min_tipi_version": "4.5.0",
-  "version": "sha-fd80e37",
+  "version": "sha-876d6d3",
   "source": "https://github.com/FPVibe/fpv-inventory",
   "website": "https://github.com/FPVibe/fpv-inventory",
   "exposable": true,

--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -10,9 +10,9 @@
     "data"
   ],
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
-  "tipi_version": 15,
+  "tipi_version": 16,
   "min_tipi_version": "4.5.0",
-  "version": "sha-876d6d3",
+  "version": "sha-fd80e37",
   "source": "https://github.com/FPVibe/fpv-inventory",
   "website": "https://github.com/FPVibe/fpv-inventory",
   "exposable": true,

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/fpvibe/fpv-inventory:sha-fd80e37",
+      "image": "ghcr.io/cori/fpv-inventory:sha-876d6d3",
       "isMain": true,
       "environment": [
         { "key": "DB_PATH", "value": "/data/fpv-inventory.db" },

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/cori/fpv-inventory:sha-876d6d3",
+      "image": "ghcr.io/fpvibe/fpv-inventory:sha-fd80e37",
       "isMain": true,
       "environment": [
         { "key": "DB_PATH", "value": "/data/fpv-inventory.db" },


### PR DESCRIPTION
The ghcr.io/fpvibe/fpv-inventory package is now public. Switch the image from the old ghcr.io/cori package to ghcr.io/fpvibe with the latest tag.

- Image: `ghcr.io/cori/fpv-inventory:sha-876d6d3` → `ghcr.io/fpvibe/fpv-inventory:sha-fd80e37`
- tipi_version: 15 → 16