### PR TITLE
app: update fpv-inventory to sha-b5324fd (auto)

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -10,9 +10,9 @@
     "data"
   ],
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "min_tipi_version": "4.5.0",
-  "version": "sha-876d6d3",
+  "version": "sha-b5324fd",
   "source": "https://github.com/FPVibe/fpv-inventory",
   "website": "https://github.com/FPVibe/fpv-inventory",
   "exposable": true,

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/cori/fpv-inventory:sha-876d6d3",
+      "image": "ghcr.io/fpvibe/fpv-inventory:sha-b5324fd",
       "isMain": true,
       "environment": [
         { "key": "DB_PATH", "value": "/data/fpv-inventory.db" },


### PR DESCRIPTION
Automated update from fpv-inventory push to main.

- Version: sha-b5324fd
- tipi_version: 17
- Image: ghcr.io/fpvibe/fpv-inventory:sha-b5324fd

All validation tests pass.