### PR TITLE
app: update fpv-inventory to 437c5f0 (auto)

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -10,9 +10,9 @@
     "data"
   ],
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
-  "tipi_version": 16,
+  "tipi_version": 17,
   "min_tipi_version": "4.5.0",
-  "version": "sha-876d6d3",
+  "version": "sha-437c5f0",
   "source": "https://github.com/FPVibe/fpv-inventory",
   "website": "https://github.com/FPVibe/fpv-inventory",
   "exposable": true,
@@ -21,7 +21,7 @@
     "amd64"
   ],
   "created_at": 1740700800000,
-  "updated_at": 1786595610000,
+  "updated_at": 1786624198000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,13 +3,25 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/cori/fpv-inventory:sha-876d6d3",
+      "image": "ghcr.io/FPVibe/fpv-inventory:sha-437c5f0",
       "isMain": true,
       "environment": [
-        { "key": "DB_PATH", "value": "/data/fpv-inventory.db" },
-        { "key": "PHOTOS_DIR", "value": "/data/photos" },
-        { "key": "PORT", "value": "8000" },
-        { "key": "TZ", "value": "${TZ}" }
+        {
+          "key": "DB_PATH",
+          "value": "/data/fpv-inventory.db"
+        },
+        {
+          "key": "PHOTOS_DIR",
+          "value": "/data/photos"
+        },
+        {
+          "key": "PORT",
+          "value": "8000"
+        },
+        {
+          "key": "TZ",
+          "value": "${TZ}"
+        }
       ],
       "volumes": [
         {


### PR DESCRIPTION
Automated update from fpv-inventory push to main.

  - Version: 437c5f0
  - tipi_version: 17
  - Image: ghcr.io/FPVibe/fpv-inventory:sha-437c5f0

  All validation tests pass.