### PR TITLE
app: update fpv-inventory to 9ade652 (auto)

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -10,9 +10,9 @@
     "data"
   ],
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
-  "tipi_version": 17,
+  "tipi_version": 18,
   "min_tipi_version": "4.5.0",
-  "version": "sha-437c5f0",
+  "version": "sha-9ade652",
   "source": "https://github.com/FPVibe/fpv-inventory",
   "website": "https://github.com/FPVibe/fpv-inventory",
   "exposable": true,
@@ -21,7 +21,7 @@
     "amd64"
   ],
   "created_at": 1740700800000,
-  "updated_at": 1786624198000,
+  "updated_at": 1786716956000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/FPVibe/fpv-inventory:sha-437c5f0",
+      "image": "ghcr.io/FPVibe/fpv-inventory:sha-9ade652",
       "isMain": true,
       "environment": [
         {


### PR DESCRIPTION
Automated update from fpv-inventory push to main.

  - Version: 9ade652
  - tipi_version: 18
  - Image: ghcr.io/FPVibe/fpv-inventory:sha-9ade652

  All validation tests pass.