### PR TITLE
app: update fpv-inventory to a33f4d9 (auto)

### DIFF
--- a/apps/fpv-inventory/config.json
+++ b/apps/fpv-inventory/config.json
@@ -10,9 +10,9 @@
     "data"
   ],
   "description": "FPV Inventory is a self-hosted web app for tracking your FPV drone parts and components. It lets you catalog parts with statuses (unused, in-use, broken, retired, lost), attach photos, view part history, and filter by location or build. Built with Deno and SQLite, it features a dark-themed mobile-friendly UI with no external dependencies.",
-  "tipi_version": 21,
+  "tipi_version": 22,
   "min_tipi_version": "4.5.0",
-  "version": "sha-f8f5348",
+  "version": "sha-a33f4d9",
   "source": "https://github.com/FPVibe/fpv-inventory",
   "website": "https://github.com/FPVibe/fpv-inventory",
   "exposable": true,
@@ -21,7 +21,7 @@
     "amd64"
   ],
   "created_at": 1740700800000,
-  "updated_at": 1786798038000,
+  "updated_at": 1786801260000,
   "dynamic_config": true,
   "form_fields": [
     {

--- a/apps/fpv-inventory/docker-compose.json
+++ b/apps/fpv-inventory/docker-compose.json
@@ -3,7 +3,7 @@
   "services": [
     {
       "name": "fpv-inventory",
-      "image": "ghcr.io/fpvibe/fpv-inventory:sha-f8f5348",
+      "image": "ghcr.io/fpvibe/fpv-inventory:sha-a33f4d9",
       "isMain": true,
       "environment": [
         {


### PR DESCRIPTION
Automated update from fpv-inventory push to main.

  - Version: a33f4d9
  - tipi_version: 22
  - Image: ghcr.io/fpvibe/fpv-inventory:sha-a33f4d9

  All validation tests pass.